### PR TITLE
Update docker.yml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,8 +67,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{needs.version-collector.outputs.package-version}}
 
-      - name: Build and push latest main Docker image
-        if: github.ref == 'refs/heads/main'
+      - name: Build and push latest Docker image
+        if: github.event_name == 'release' || github.ref == 'refs/heads/main'
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
         with:
           push: true


### PR DESCRIPTION
This pull request includes a modification to the `.github/workflows/docker.yml` file. The change alters the condition for building and pushing the latest Docker image. Previously, this action was only executed if the branch was `main`. Now, the action will also execute if the event triggering the workflow is a `release`.

Here's the key change:

* <a href="diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L70-R71">`.github/workflows/docker.yml`</a>: Updated the condition for the "Build and push latest Docker image" job to execute not only when the branch is `main`, but also when a `release` event occurs.