### PR TITLE
Update version to 1.4.3 in package-lock.json and package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-webhook-dispatcher",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "github-webhook-dispatcher",
-      "version": "1.4.1",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-webhook-dispatcher",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "description": "API endpoint to route GitHub webhooks to specified targets",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
This pull request includes a minor change to the `package.json` file. The version of the `github-webhook-dispatcher` has been updated from `1.4.1` to `1.4.3`.