### PR TITLE
Potential fix for code scanning alert no. 48: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
   name: ci-javascript
+  permissions:
+    contents: read
 
   on:
     workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/collinmcneese/github-webhook-dispatcher/security/code-scanning/48](https://github.com/collinmcneese/github-webhook-dispatcher/security/code-scanning/48)

To fix the problem, you should explicitly add a `permissions` block to the workflow (at the top level or per job) to limit the `GITHUB_TOKEN` permissions to the minimum necessary. Since the jobs shown (dependency review and validation) do not require write access, the minimal permission is `contents: read`. This can be applied at the root of the workflow YAML file, ensuring all jobs inherit these restricted permissions, unless overridden. 

To implement this, add the following block after the `name` field and before the `on` field in `.github/workflows/ci.yml`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
