### PR TITLE
Update Node.js version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          node-version: [20.x]
+          node-version: [24]
       steps:
         - uses: actions/checkout@v5
         - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
* Updated the Node.js version in `.github/workflows/ci.yml` from `20.x` to `24` to ensure the CI pipeline uses the latest supported Node.js release.